### PR TITLE
Fix non-empty <body> class name forcing light theme

### DIFF
--- a/bqncrate.css
+++ b/bqncrate.css
@@ -4,8 +4,8 @@ i{display:none}
 html,body{height:100%}
 body{display:flex;flex-flow:column;margin:0;font-size:16px;
   overflow:hidden;position:relative;color:#222;  content:"w";background:#ddd                   }  .w{background:#ddd;filter:invert(0)}
-@media(prefers-color-scheme:dark){body[class=""]{content:"g";background:#444;filter:invert(.85)}} .g{background:#444;filter:invert(.85)}
-@media(prefers-contrast:more)    {body[class=""]{content:"b";background:#222;filter:invert(1)  }} .b{background:#222;filter:invert(1)}
+@media(prefers-color-scheme:dark){body{content:"g";background:#444;filter:invert(.85)}} .g{background:#444;filter:invert(.85)}
+@media(prefers-contrast:more)    {body{content:"b";background:#222;filter:invert(1)  }} .b{background:#222;filter:invert(1)}
 .f{display:flex} .h{padding:0.5em}
 .o,#m{margin:0 0.35em} label{margin-left:0.35em}
 #q{flex:1;border:none;font-size:medium;margin-right:-1.5em} #x{margin-right:0.5em}


### PR DESCRIPTION
I've got an unrelated Chrome extension enabled and it adds the [`vsc-intialized`](https://stackoverflow.com/questions/53381500/what-is-vsc-initialized) class to the `<body>` element, and so this works around that.

The search params `?w`, `?b` and `?d` still work to set the scheme to your desired setting.